### PR TITLE
Fix vendor:publish "Can't locate path: <0>" bug

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,7 +34,9 @@ class ServiceProvider extends LaravelServiceProvider
     public function boot()
     {
         // declare the configuration files available for publishing.
-        $this->publishes([__DIR__.'../config/jwt.php'], 'config');
+        $this->publishes([
+            __DIR__.'../config/jwt.php' => config_path('jwt.php')
+        ]);
 
         // case enabled, setups a guard match by middleware group name.
         $this->setupGuardMiddlewareMatch();


### PR DESCRIPTION
Was getting a bug, 'Can't locate path: <0>', when running 'php artisan vendor:publish --provider="Codecasts\Auth\JWT\ServiceProvider"'. This is the fix to that error. Has not been tested on multiple versions of Laravel but looks simple enough. The publishes method should take a key => value array, not a simple text array as was previously in the code.