### PR TITLE
support protected Authenticatable identifier

### DIFF
--- a/src/Token/Manager.php
+++ b/src/Token/Manager.php
@@ -241,7 +241,7 @@ class Manager implements ManagerContract
         $builder->setIssuer($this->issuer);
 
         // set the subject.
-        $builder->setSubject($user->{$user->getAuthIdentifierName()});
+        $builder->setSubject($user->getAuthIdentifier());
 
         // generate a unique id for the token, and set it to replicate as a header.
         $builder->setId($this->generateId(), true);


### PR DESCRIPTION
I was using this package with `laravel-doctrine`, and I get error if my Authenticable entity have a protected/private identifier.
Now, the token manager use the identifier getter function rather than accessing it directly.

PS: thanks for the package, it is awesomely simple.
