### PR TITLE
update key generate command to work in laravel 5.5

### DIFF
--- a/src/Console/KeyGenerateCommand.php
+++ b/src/Console/KeyGenerateCommand.php
@@ -24,7 +24,7 @@ class KeyGenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // call the action to generate a new key.
         $key = $this->generateRandomKey();


### PR DESCRIPTION
fixes #10
Laravel 5.5 requires changing `fire` method to `handle`, however there will be no BC as the handle method is supported since Laravel 5.0
