### PR TITLE
Added accessor to the detected token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 composer.lock
 /vendor
-.idea
-.idea/encodings.xml
-.idea/vcs.xml
-.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 composer.lock
 /vendor
+.idea
+.idea/encodings.xml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -92,6 +92,13 @@ class Guard implements GuardContract
     protected $lastAttempted;
 
     /**
+     * The detected JWT token.
+     *
+     * @var string
+     */
+    protected $token = null;
+
+    /**
      * JWT Guard constructor.
      *
      * @param \Illuminate\Contracts\Foundation\Application $app
@@ -268,7 +275,7 @@ class Guard implements GuardContract
         // if a token was found...
         if ($headerToken) {
             // return a new token instance.
-            return $this->manager()->parseToken($headerToken);
+            $this->token = $this->manager()->parseToken($headerToken);
         }
 
         // try to find a token passed as parameter on the request.
@@ -276,11 +283,11 @@ class Guard implements GuardContract
 
         // if found...
         if ($parameterToken) {
-            return $this->manager()->parseToken($parameterToken);
+            $this->token = $this->manager()->parseToken($parameterToken);
         }
 
         // return null if no token could be found.
-        return null;
+        return $this->token;
     }
 
     /**
@@ -480,4 +487,15 @@ class Guard implements GuardContract
 
         return $this;
     }
+
+    /**
+     * The detected JWT token.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
 }

--- a/src/Console/KeyGenerateCommand.php
+++ b/src/Console/KeyGenerateCommand.php
@@ -24,7 +24,7 @@ class KeyGenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // call the action to generate a new key.
         $key = $this->generateRandomKey();

--- a/src/Token/Manager.php
+++ b/src/Token/Manager.php
@@ -241,7 +241,7 @@ class Manager implements ManagerContract
         $builder->setIssuer($this->issuer);
 
         // set the subject.
-        $builder->setSubject($user->{$user->getAuthIdentifierName()});
+        $builder->setSubject($user->getAuthIdentifier());
 
         // generate a unique id for the token, and set it to replicate as a header.
         $builder->setId($this->generateId(), true);


### PR DESCRIPTION
I have need of this on my project as I am baking permissions into the `aud` claim and need to get hold of them in a middleware to do further authorisation checks. I think with support for adding custom claims to the token there needs to be a simple way to get hold of the token and this made most sense to me (unless I missed an obvious alternative?!)