### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "orchestra/testbench": "^3.4",
         "phpunit/phpunit": "^6.1",
-        "mockery/mockery": "^0.9.9"
+        "mockery/mockery": "^1.0"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).