### PR TITLE
make setupSecret() method public

### DIFF
--- a/src/Contracts/Token/Manager.php
+++ b/src/Contracts/Token/Manager.php
@@ -18,6 +18,11 @@ interface Manager
     public function __construct(Config $config, Cache $cache);
 
     /**
+     * Setup the secret that will be used to sign keys.
+     */
+    public function setupSecret();
+
+    /**
      * @param Authenticatable $user
      * @param array $customClaims
      *

--- a/src/Token/Manager.php
+++ b/src/Token/Manager.php
@@ -99,7 +99,7 @@ class Manager implements ManagerContract
     /**
      * Setup the secret that will be used to sign keys.
      */
-    protected function setupSecret()
+    public function setupSecret()
     {
         // gets the key from config.
         $secret = $this->config->get('jwt.secret');


### PR DESCRIPTION
This will allow to change the secret key after initialization: see https://github.com/codecasts/laravel-jwt/issues/26

Now you can do:

```php
Config::set('jwt.secret', $new_secret);
Auth::guard()->manager()->setupSecret();
```