### PR TITLE
Add matrix to run tests on PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   include:
     - php: 7.0
     - php: 7.1
+    - php: 7.2
     - php: nightly
   fast_finish: true
 


### PR DESCRIPTION
Add a matrix to `travis.yml` to also run tests using PHP 7.2.