### PR TITLE
fix middleware group match and guard creation

### DIFF
--- a/src/Auth/ServiceProvider.php
+++ b/src/Auth/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends AuthServiceProvider
             $guard->setDispatcher(resolve(Dispatcher::class));
 
             // returns the guard instance.
-            return new Guard($app, $name, $userProvider, $tokenManager);
+            return $guard;
         });
     }
 

--- a/src/Auth/ServiceProvider.php
+++ b/src/Auth/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends AuthServiceProvider
             $guard->setDispatcher(resolve(Dispatcher::class));
 
             // returns the guard instance.
-            return $guard;
+            return new Guard($app, $name, $userProvider, $tokenManager);
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -98,11 +98,17 @@ class ServiceProvider extends LaravelServiceProvider
                 // get the route middleware group.
                 $middlewareGroup = Arr::first((array) $event->route->middleware());
 
-                // if there is a group detected and  there is a guard that matches the middleware
+                // if there is a group detected and there is a guard that matches the middleware
                 // group name...
-                if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
-                    // setup the matching guard as default.
-                    $this->app['auth']->setDefaultDriver($middlewareGroup);
+                if ($middlewareGroup) {
+
+                    try {
+                        $this->app['auth']->guard($middlewareGroup);
+                        // setup the matching guard as default.
+                        $this->app['auth']->setDefaultDriver($middlewareGroup);
+                    } catch (\Exception $e) {
+                    }
+                    
                 }
             });
         }


### PR DESCRIPTION
The `guard($name)` method in `Illuminate\Auth\AuthManager` throws `InvalidArgumentException`.

The check done in the `setupGuardMiddlewareMatch()` method in `Codecasts\Auth\JWT\ServiceProvider` is not enough:

```php
if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
    $this->app['auth']->setDefaultDriver($middlewareGroup);
}
```
this will throw an exception if the guard is not found.

This PR fixes this like this:
```php
if ($middlewareGroup) {
    try {
        $this->app['auth']->guard($middlewareGroup);
        $this->app['auth']->setDefaultDriver($middlewareGroup);
    } catch (\Exception $e) {
    }
}
```