### PR TITLE
fix middleware group match by catching exception

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -100,13 +100,12 @@ class ServiceProvider extends LaravelServiceProvider
 
                 // if there is a group detected and there is a guard that matches the middleware
                 // group name...
-                if ($middlewareGroup) {
-                    try {
-                        $this->app['auth']->guard($middlewareGroup);
+                try {
+                    if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
                         // setup the matching guard as default.
                         $this->app['auth']->setDefaultDriver($middlewareGroup);
-                    } catch(\Exception $e) {}
-                }
+                    }
+                } catch(\Exception $e) {}
             });
         }
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -98,11 +98,14 @@ class ServiceProvider extends LaravelServiceProvider
                 // get the route middleware group.
                 $middlewareGroup = Arr::first((array) $event->route->middleware());
 
-                // if there is a group detected and  there is a guard that matches the middleware
+                // if there is a group detected and there is a guard that matches the middleware
                 // group name...
-                if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
-                    // setup the matching guard as default.
-                    $this->app['auth']->setDefaultDriver($middlewareGroup);
+                if ($middlewareGroup) {
+                    try {
+                        $this->app['auth']->guard($middlewareGroup);
+                        // setup the matching guard as default.
+                        $this->app['auth']->setDefaultDriver($middlewareGroup);
+                    } catch(\Exception $e) {}
                 }
             });
         }


### PR DESCRIPTION
The `guard($name)` method in `Illuminate\Auth\AuthManager` throws `InvalidArgumentException`.

The check done in the `setupGuardMiddlewareMatch()` method in `Codecasts\Auth\JWT\ServiceProvider` is not enough:

```php
if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
    $this->app['auth']->setDefaultDriver($middlewareGroup);
}
```
this will throw an exception if the guard is not found.

This PR fixes this like this:
```php
try {
    if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
        // setup the matching guard as default.
        $this->app['auth']->setDefaultDriver($middlewareGroup);
    }
} catch(\Exception $e) {}
```