### PR TITLE
Laravel 5.7

### DIFF
--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -124,7 +124,7 @@ class Guard implements GuardContract
     protected function fireAttemptEvent(array $credentials)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Attempting('jwt', $credentials, false));
+            $this->events->dispatch(new Attempting($this->name, $credentials, false));
         }
     }
 
@@ -138,7 +138,7 @@ class Guard implements GuardContract
     protected function fireFailedEvent($user, array $credentials)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Failed('jwt', $user, $credentials));
+            $this->events->dispatch(new Failed($this->name, $user, $credentials));
         }
     }
 
@@ -152,7 +152,7 @@ class Guard implements GuardContract
     protected function fireLoginEvent($user)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Login('jwt', $user, false));
+            $this->events->dispatch(new Login($this->name, $user, false));
         }
     }
 

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -124,9 +124,7 @@ class Guard implements GuardContract
     protected function fireAttemptEvent(array $credentials)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Attempting(
-                $credentials, false
-            ));
+            $this->events->dispatch(new Attempting('jwt', $credentials, false));
         }
     }
 
@@ -140,7 +138,7 @@ class Guard implements GuardContract
     protected function fireFailedEvent($user, array $credentials)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Failed($user, $credentials));
+            $this->events->dispatch(new Failed('jwt', $user, $credentials));
         }
     }
 
@@ -154,7 +152,7 @@ class Guard implements GuardContract
     protected function fireLoginEvent($user)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Login($user, false));
+            $this->events->dispatch(new Login('jwt', $user, false));
         }
     }
 

--- a/src/Auth/ServiceProvider.php
+++ b/src/Auth/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends AuthServiceProvider
             $guard->setDispatcher(resolve(Dispatcher::class));
 
             // returns the guard instance.
-            return new Guard($app, $name, $userProvider, $tokenManager);
+            $guard;
         });
     }
 

--- a/src/Auth/ServiceProvider.php
+++ b/src/Auth/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends AuthServiceProvider
             $guard->setDispatcher(resolve(Dispatcher::class));
 
             // returns the guard instance.
-            $guard;
+            return $guard;
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -100,13 +100,12 @@ class ServiceProvider extends LaravelServiceProvider
 
                 // if there is a group detected and there is a guard that matches the middleware
                 // group name...
-                if ($middlewareGroup) {
-                    try {
-                        $this->app['auth']->guard($middlewareGroup);
+                try {
+                    if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
                         // setup the matching guard as default.
                         $this->app['auth']->setDefaultDriver($middlewareGroup);
-                    } catch(\Exception $e) {}
-                }
+                    }
+                } catch(\Exception $e) {}
             });
         }
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -98,11 +98,14 @@ class ServiceProvider extends LaravelServiceProvider
                 // get the route middleware group.
                 $middlewareGroup = Arr::first((array) $event->route->middleware());
 
-                // if there is a group detected and  there is a guard that matches the middleware
+                // if there is a group detected and there is a guard that matches the middleware
                 // group name...
-                if ($middlewareGroup && !!$this->app['auth']->guard($middlewareGroup)) {
-                    // setup the matching guard as default.
-                    $this->app['auth']->setDefaultDriver($middlewareGroup);
+                if ($middlewareGroup) {
+                    try {
+                        $this->app['auth']->guard($middlewareGroup);
+                        // setup the matching guard as default.
+                        $this->app['auth']->setDefaultDriver($middlewareGroup);
+                    } catch(\Exception $e) {}
                 }
             });
         }


### PR DESCRIPTION
The `__construct` method of Auth events has a new `$guard argument` in Laravel 5.7:
```php
public function __construct($guard, $user, $remember)
```
See: https://laravel.com/docs/5.7/upgrade

We now need to pass the guard name, otherwise an error will brake the application. This PR fixes that. It will work with Laravel >= 5.7