### PR TITLE
Allowed token detection methods to be defined in config file

### DIFF
--- a/config/jwt.php
+++ b/config/jwt.php
@@ -99,4 +99,21 @@ return [
 
     'middleware_match' => true,
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token detection from request methods
+    |--------------------------------------------------------------------------
+    |
+    | Use an array of strings including: parameter, header
+    |
+    | Header will check the request for the Authorization: Bearer TOKEN header
+    | Parameter will check for the token the request body "token" parameters
+    |
+     */
+    'token_detections' => [
+        'parameter',
+        'header'
+    ]
+
 ];

--- a/src/Auth/ServiceProvider.php
+++ b/src/Auth/ServiceProvider.php
@@ -45,6 +45,11 @@ class ServiceProvider extends AuthServiceProvider
             // set a event dispatcher on the guard.
             $guard->setDispatcher(resolve(Dispatcher::class));
 
+            $detections = $this->app['config']->get('jwt.token_detections', ['parameter', 'header']);
+
+            // set the token detection methods
+            $guard->setTokenDetections($detections);
+
             // returns the guard instance.
             return new Guard($app, $name, $userProvider, $tokenManager);
         });


### PR DESCRIPTION
My use case was that only Authorization: Bearer should be allowed and not token via a GET or POST parameter.

The requirement for this is to remove the risk of CSRF or use of cross origin requests with stolen or compromised tokens.